### PR TITLE
fix: Use user provided Content-Type for multipart object upload if provided.

### DIFF
--- a/src/gcp.js
+++ b/src/gcp.js
@@ -135,7 +135,7 @@ const putObjectMultipart = (object, filePath, token, headers) => Promise.resolve
 		'',
 		`--${boundary}`,
 		`Content-Disposition: form-data; name="${file}"; filename="${file}"`,
-		`Content-Type: ${contentType}`,
+		`Content-Type: ${headers['Content-Type'] || headers['content-type'] || contentType}`,
 		'',
 		''
 	].join('\r\n')


### PR DESCRIPTION
Otherwise, multipart form uploads will fail if the content type can not be inferred by file extension.